### PR TITLE
feat: add authentication endpoints to API

### DIFF
--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -1,0 +1,2 @@
+export const JWT_SECRET = process.env.JWT_SECRET || 'dev-secret';
+export const JWT_EXPIRES_IN = process.env.JWT_EXPIRES_IN || '7d';

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -2,17 +2,29 @@ import 'dotenv/config';
 import express from 'express';
 import cors from 'cors';
 import mongoose from 'mongoose';
+import authRouter from './routes/auth.js';
+import { authenticate, type AuthRequest } from './middleware/auth.js';
 
 const app = express();
-app.use(cors({ origin: (process.env.CLIENT_ORIGINS||'').split(',').filter(Boolean) }));
+app.use(cors({ origin: (process.env.CLIENT_ORIGINS || '').split(',').filter(Boolean) }));
 app.use(express.json());
-app.get('/health', (_req, res) => res.json({ ok: true }));
 
-const port = Number(process.env.PORT||4000);
+app.get('/health', (_req, res) => res.json({ ok: true }));
+app.use('/auth', authRouter);
+app.get('/me', authenticate, (req, res) => {
+  const { user } = req as AuthRequest;
+  res.json({ user });
+});
+
+const port = Number(process.env.PORT || 4000);
 const mongo = process.env.MONGO_URL || 'mongodb://localhost:27017/skillswap';
 
 async function main() {
   await mongoose.connect(mongo);
   app.listen(port, () => console.log(`API on :${port}`));
 }
-main().catch(err => { console.error(err); process.exit(1); });
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -1,0 +1,46 @@
+import type { NextFunction, Request, Response } from 'express';
+import jwt, { type JwtPayload } from 'jsonwebtoken';
+import { JWT_SECRET } from '../config.js';
+import { User } from '../models/User.js';
+
+export interface AuthenticatedUser {
+  id: string;
+  name: string;
+  email: string;
+}
+
+export interface AuthRequest extends Request {
+  user?: AuthenticatedUser;
+}
+
+export async function authenticate(req: AuthRequest, res: Response, next: NextFunction) {
+  const authorization = req.headers.authorization;
+  if (!authorization || !authorization.startsWith('Bearer ')) {
+    return res.status(401).json({ message: 'Unauthorized' });
+  }
+
+  const token = authorization.slice(7);
+
+  try {
+    const payload = jwt.verify(token, JWT_SECRET) as JwtPayload & { sub?: string };
+    const userId = payload.sub;
+    if (!userId) {
+      return res.status(401).json({ message: 'Unauthorized' });
+    }
+
+    const user = await User.findById(userId).select('-password').lean();
+    if (!user) {
+      return res.status(401).json({ message: 'Unauthorized' });
+    }
+
+    req.user = {
+      id: user._id.toString(),
+      name: user.name,
+      email: user.email,
+    };
+
+    next();
+  } catch (error) {
+    return res.status(401).json({ message: 'Unauthorized' });
+  }
+}

--- a/apps/api/src/models/User.ts
+++ b/apps/api/src/models/User.ts
@@ -1,0 +1,20 @@
+import { Schema, model, type Document, type Model } from 'mongoose';
+
+export interface UserDocument extends Document {
+  name: string;
+  email: string;
+  password: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const UserSchema = new Schema<UserDocument>(
+  {
+    name: { type: String, required: true, trim: true },
+    email: { type: String, required: true, unique: true, lowercase: true, trim: true },
+    password: { type: String, required: true },
+  },
+  { timestamps: true }
+);
+
+export const User: Model<UserDocument> = model<UserDocument>('User', UserSchema);

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -1,0 +1,76 @@
+import { Router } from 'express';
+import bcrypt from 'bcryptjs';
+import jwt from 'jsonwebtoken';
+import { JWT_EXPIRES_IN, JWT_SECRET } from '../config.js';
+import { User } from '../models/User.js';
+import type { AuthenticatedUser } from '../middleware/auth.js';
+
+const authRouter = Router();
+
+function toProfile(user: { id?: string; _id?: unknown; name: string; email: string }): AuthenticatedUser {
+  const id = typeof user.id === 'string' ? user.id : String(user._id);
+  return { id, name: user.name, email: user.email };
+}
+
+function createToken(userId: string) {
+  return jwt.sign({ sub: userId }, JWT_SECRET, { expiresIn: JWT_EXPIRES_IN });
+}
+
+authRouter.post('/register', async (req, res) => {
+  const { name, email, password } = req.body ?? {};
+
+  if (!name || !email || !password) {
+    return res.status(400).json({ message: 'Name, email, and password are required' });
+  }
+
+  try {
+    const normalizedEmail = String(email).toLowerCase();
+    const existingUser = await User.findOne({ email: normalizedEmail });
+
+    if (existingUser) {
+      return res.status(409).json({ message: 'Email already in use' });
+    }
+
+    const hashedPassword = await bcrypt.hash(password, 10);
+    const user = await User.create({ name, email: normalizedEmail, password: hashedPassword });
+    const profile = toProfile(user);
+    const token = createToken(profile.id);
+
+    return res.status(201).json({ token, user: profile });
+  } catch (error) {
+    console.error('Failed to register user', error);
+    return res.status(500).json({ message: 'Unable to register user' });
+  }
+});
+
+authRouter.post('/login', async (req, res) => {
+  const { email, password } = req.body ?? {};
+
+  if (!email || !password) {
+    return res.status(400).json({ message: 'Email and password are required' });
+  }
+
+  try {
+    const normalizedEmail = String(email).toLowerCase();
+    const user = await User.findOne({ email: normalizedEmail });
+
+    if (!user) {
+      return res.status(401).json({ message: 'Invalid credentials' });
+    }
+
+    const passwordMatches = await bcrypt.compare(password, user.password);
+    if (!passwordMatches) {
+      return res.status(401).json({ message: 'Invalid credentials' });
+    }
+
+    const profile = toProfile(user);
+    const token = createToken(profile.id);
+
+    return res.json({ token, user: profile });
+  } catch (error) {
+    console.error('Failed to login user', error);
+    return res.status(500).json({ message: 'Unable to login user' });
+  }
+});
+
+export default authRouter;


### PR DESCRIPTION
## Summary
- add JWT configuration and Mongoose user model
- implement register and login routes that hash passwords and return tokens
- add authentication middleware and /me endpoint for returning the current user profile

## Testing
- `pnpm -C apps/api build` *(fails: unable to download pnpm due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68e539f9e76883329e25acb2e13174ee